### PR TITLE
enable encoding of combined emojis

### DIFF
--- a/lib/rumoji/emoji.rb
+++ b/lib/rumoji/emoji.rb
@@ -62,10 +62,16 @@ module Rumoji
     autoload :PLACES, 'rumoji/emoji/places'
     autoload :SYMBOLS, 'rumoji/emoji/symbols'
     autoload :NEWMOJI, 'rumoji/emoji/newmoji'
+    autoload :COMBINE, 'rumoji/emoji/combine'
 
-    ALL = PEOPLE | NATURE | OBJECTS | PLACES | SYMBOLS | FOOD | NEWMOJI
+    ALL = COMBINE | PEOPLE | NATURE | OBJECTS | PLACES | SYMBOLS | FOOD | NEWMOJI
+    SINGLE_EMOJI = PEOPLE | NATURE | OBJECTS | PLACES | SYMBOLS | FOOD | NEWMOJI
 
-    ALL_REGEXP = Regexp.new(ALL.map(&:string).join('|'))
+    JOINED_SINGLE_EMOJI = SINGLE_EMOJI.map(&:string).join('|')
+    JOINED_COMBINE_EMOJI = COMBINE.map(&:string).join('|')
+    JOINED_ALL_EMOJI = JOINED_COMBINE_EMOJI << '|' << JOINED_SINGLE_EMOJI
+
+    ALL_REGEXP = Regexp.new(JOINED_ALL_EMOJI)
 
     SYMBOL_LOOKUP = ALL.each.with_object({}) do |emoji, lookup|
       emoji.symbols.each do |symbol|

--- a/lib/rumoji/emoji/combine.rb
+++ b/lib/rumoji/emoji/combine.rb
@@ -1,0 +1,12 @@
+# -*- encoding: utf-8 -*-
+
+require 'rumoji/emoji'
+require 'set'
+
+module Rumoji
+  class Emoji
+    COMBINE = SortedSet[
+      self.new("\u{2764 FE0F 200D 1F525}", [:heart_on_fire]),
+    ]
+  end
+end

--- a/lib/rumoji/emoji/people.rb
+++ b/lib/rumoji/emoji/people.rb
@@ -256,7 +256,6 @@ module Rumoji
       self.new("\u{1FA76}", [:grey_heart]),
       self.new("\u{1F970}", [:smiling_face_with_hearts]),
       self.new("\u{1F973}", [:partying_face]),
-      self.new("\u{2764 FE0F 200D 1F525}", [:heart_on_fire]),
       self.new("\u{1F929}", [:star_struck]),
     ]
   end


### PR DESCRIPTION
## About
Encoding the "combined emoji" results in "single emoji1" and "single emoji2".

### Example
```
// Actual result
Rumoji.encode("❤️‍🔥") = ":red_heart:‍:fire:"

// Expected result
Rumoji.encode("❤️‍🔥") = ":heart_on_fire:"
```